### PR TITLE
Feature/add hhvm compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 .build/
 .idea/
 nbproject/
+.editorconfig
 
 # Compass/SASS/SCSS
 .sass-cache

--- a/wp-gears-runner.php
+++ b/wp-gears-runner.php
@@ -5,6 +5,16 @@
  * IMPORTANT: This file must be placed in (or symlinked to) the root of the WordPress install!
  */
 
+/**
+ * The libgearman extension is not compatible with HHVM. We exit early
+ * here to prevent HHVM from hanging and then crashing eventually.
+ */
+if ( defined( 'HHVM_VERSION' ) ) {
+	die(
+		"Fatal Error: WP Gears and the libgearman extension are not compatible with HHVM.\n"
+	);
+}
+
 ignore_user_abort(true);
 
 if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_ASYNC' ) ) {


### PR DESCRIPTION
This PR add support to exit early if WP Gears is under HHVM, with a fatal error message. 

Fixes #1.

We should remove this if future releases of libgearman and HHVM become compatible.
