### PR TITLE
Refactoring WP Gears to improve Testability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 
 /vendor/
 /release/
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=3.9 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=3.9 WP_MULTISITE=1
+
+branches:
+  except:
+    - /^dist-.*$/
+
+install:
+  - composer install --dev
+
+before_script:
+  - bash bin/install-wp-tests.sh wordpress_test travis ''  localhost $WP_VERSION
+
+script:
+  - ./vendor/bin/phpunit

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,32 @@
+<?php
+
+function wp_gears_autoloader() {
+	global $wp_gears_autoloaded;
+
+	if ( ! $wp_gears_autoloaded ) {
+		$composer_autoloader = __DIR__ . '/vendor/autoload.php';
+
+		if ( file_exists( $composer_autoloader ) ) {
+			require_once( $composer_autoloader );
+		} else {
+			spl_autoload_register( 'wp_gears_autoload' );
+		}
+
+		$wp_gears_autoloaded = true;
+	}
+}
+
+function wp_gears_autoload( $class_path ) {
+	if ( strpos( $class_path, 'WpGears\\' ) !== false ) {
+		$class_file  = __DIR__ . '/includes/';
+		$class_file .= str_replace( '\\', '/', $class_path );
+		$class_file .= '.php';
+
+		if ( file_exists( $class_file ) ) {
+			require_once( $class_file );
+		}
+	}
+}
+
+
+

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=/tmp/wordpress/
+
+set -ex
+
+install_wp() {
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then 
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite
+	mkdir -p $WP_TESTS_DIR
+	cd $WP_TESTS_DIR
+	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+
+	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
+	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
+	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
+	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
+	sed $ioption "s|localhost|${DB_HOST}|" wp-tests-config.php
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,23 +12,58 @@ DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=/tmp/wordpress/
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
 
 set -ex
 
 install_wp() {
-	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then 
-		local ARCHIVE_NAME='latest'
-	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	if [ -d $WP_CORE_DIR ]; then
+		return;
 	fi
 
-	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	mkdir -p $WP_CORE_DIR
 
-	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {
@@ -39,17 +74,22 @@ install_test_suite() {
 		local ioption='-i'
 	fi
 
-	# set up testing suite
-	mkdir -p $WP_TESTS_DIR
-	cd $WP_TESTS_DIR
-	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
 
-	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
-	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
-	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
-	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
-	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
-	sed $ioption "s|localhost|${DB_HOST}|" wp-tests-config.php
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
 }
 
 install_db() {
@@ -60,7 +100,7 @@ install_db() {
 	local EXTRA=""
 
 	if ! [ -z $DB_HOSTNAME ] ; then
-		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
 		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     "require": {
         "composer/installers": "~1.0",
 		"phpunit/phpunit": "~3.7"
-    }
+    },
+	"autoload": {
+		"psr-4": {
+			"WpGears\\": "includes/WpGears"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
-        "composer/installers": "~1.0"
+        "composer/installers": "~1.0",
+		"phpunit/phpunit": "~3.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,12 @@
         }
     ],
     "require": {
-        "composer/installers": "~1.0",
-		"phpunit/phpunit": "~3.7"
+        "composer/installers": "~1.0"
     },
+	"require-dev": {
+		"phpunit/phpunit": "~3.7",
+		"mockery/mockery": "~0.9.0"
+	},
 	"autoload": {
 		"psr-4": {
 			"WpGears\\": "includes/WpGears"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,527 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "66ebbd3ec3d072db1dfef6ed91fa2ba2",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.0.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/bd9b14f094c89c8b5804a4e41edeb7853bb85046",
+                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "1.0.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "4.1.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Composer\\Installers\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "http://composer.github.com/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Hurad",
+                "MODX Evo",
+                "OXID",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "elgg",
+                "fuelphp",
+                "grav",
+                "installer",
+                "joomla",
+                "kohana",
+                "laravel",
+                "lithium",
+                "magento",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "moodle",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "zend",
+                "zikula"
+            ],
+            "time": "2015-10-29 23:28:48"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "1.2.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": ">=1.3.0@stable",
+                "phpunit/php-text-template": ">=1.2.0@stable",
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-09-02 10:13:14"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2015-06-21 08:01:12"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2014-03-03 05:10:30"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "3.7.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.1",
+                "phpunit/php-timer": "~1.0",
+                "phpunit/phpunit-mock-objects": "~1.2",
+                "symfony/yaml": "~2.0"
+            },
+            "require-dev": {
+                "pear-pear.php.net/pear": "1.9.4"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "composer/bin/phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-10-17 09:04:17"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": ">=1.1.1@stable"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2013-01-13 10:24:48"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/34c8a4b51e751e7ea869b8262f883d008a2b81b8",
+                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-01-13 10:28:07"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -5,6 +5,7 @@
         "This file is @generated automatically"
     ],
     "hash": "67a3d6b641b36858188b3b92dad709c3",
+    "content-hash": "c0f8ce43b117e5832f5e87c3bd997943",
     "packages": [
         {
             "name": "composer/installers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "66ebbd3ec3d072db1dfef6ed91fa2ba2",
+    "hash": "67a3d6b641b36858188b3b92dad709c3",
     "packages": [
         {
             "name": "composer/installers",
@@ -103,6 +103,118 @@
                 "zikula"
             ],
             "time": "2015-10-29 23:28:48"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ],
+                "files": [
+                    "hamcrest/Hamcrest.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2015-05-11 14:41:42"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "0.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "70bba85e4aabc9449626651f48b9018ede04f86b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/70bba85e4aabc9449626651f48b9018ede04f86b",
+                "reference": "70bba85e4aabc9449626651f48b9018ede04f86b",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Padraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2015-04-02 19:54:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -516,7 +628,6 @@
             "time": "2016-01-13 10:28:07"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/includes/WpGears/Client.php
+++ b/includes/WpGears/Client.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WpGears;
+
+/**
+ * Base class for all WpGears Clients. A Client is responsible for
+ * adding jobs to it's Queue. It may optionally perform additional
+ * initialization to setup it's initial state.
+ */
+abstract class Client {
+
+	/**
+	 * Any implementation specific initialization goes here.
+	 *
+	 * @return bool True or false based on whether the client was registered
+	 */
+	abstract function register();
+
+	/**
+	 * Adds the job to the Queue. Clients may receive multiple calls to
+	 * add jobs to the Queue.
+	 *
+	 * @param string $hook The action hook name for the job
+	 * @param array $args Optional arguments for the job
+	 * @param string $priority Optional priority of the job
+	 * @return bool true or false depending on the Client
+	 */
+	abstract function add( $action, $params = array(), $priority );
+
+}

--- a/includes/WpGears/Cron/Client.php
+++ b/includes/WpGears/Cron/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WpGears\Cron;
+
+use WpGears\Client as BaseClient;
+
+/**
+ * The Cron Client uses WPCron to add jobs. This is the fallback used if
+ * Gearman is absent.
+ */
+class Client extends BaseClient {
+
+	/**
+	 * The Cron Client has no initialization, just returns true.
+	 *
+	 * @return bool Always true
+	 */
+	public function register() {
+		return true;
+	}
+
+	/**
+	 * Adds the job to the WP Cron queue. It will be executed on the
+	 * next WordPress request.
+	 *
+	 * @param string $hook The action hook name for the job
+	 * @param array $args Optional arguments for the job
+	 * @param string $priority Ignored in WP-Cron
+	 * @return bool Always true
+	 */
+	public function add( $hook, $args = array(), $priority = 'normal' ) {
+		// Priority isn't really something we can manage with wp-cron
+		wp_schedule_single_event( time(), $hook, $args );
+
+		return true;
+	}
+
+}

--- a/includes/WpGears/Cron/Worker.php
+++ b/includes/WpGears/Cron/Worker.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WpGears\Cron;
+
+use WpGears\Worker as BaseWorker;
+
+/**
+ * The WP-Cron implementation does not have a concept of Workers. We
+ * use stub implementations to match the required base API.
+ */
+class Worker extends BaseWorker {
+
+	/**
+	 * WP-Cron does not have an Worker initialization.
+	 *
+	 * @return bool Always true
+	 */
+	public function register() {
+		return true;
+	}
+
+	/**
+	 * Work is done automatically on the next WordPress request.
+	 *
+	 * @return bool Always true
+	 */
+	function work() {
+		return true;
+	}
+
+}

--- a/includes/WpGears/Gearman/Client.php
+++ b/includes/WpGears/Gearman/Client.php
@@ -170,7 +170,7 @@ class Client extends BaseClient {
 	 */
 	function get_blog_id() {
 		if ( is_null( $this->blog_id ) ) {
-			if ( defined( 'is_multisite' ) && is_multisite() ) {
+			if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 				$this->blog_id = get_current_blog_id();
 			} else {
 				$this->blog_id = false;

--- a/includes/WpGears/Gearman/Client.php
+++ b/includes/WpGears/Gearman/Client.php
@@ -37,6 +37,7 @@ class Client extends BaseClient {
 
 		if ( $client !== false ) {
 			$servers = $this->get_servers();
+			var_dump( $client );
 
 			if ( empty( $servers ) ) {
 				return $client->addServer();

--- a/includes/WpGears/Gearman/Client.php
+++ b/includes/WpGears/Gearman/Client.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace WpGears\Gearman;
+
+use WpGears\Client as BaseClient;
+
+/**
+ * The Gearman Client uses the libGearman API to add jobs to the Gearman
+ * Queue. The servers that the client should connect to are setup as
+ * part of the initialization.
+ */
+class Client extends BaseClient {
+
+	/**
+	 * @var GearmanClient The libGearman Client instance
+	 */
+	public $gearman_client;
+
+	/**
+	 * @var array The list of Gearman Servers to connect to.
+	 */
+	public $gearman_servers;
+
+	/**
+	 * @var int The blog_id of the current multisite install.
+	 */
+	public $blog_id;
+
+	/**
+	 * Creates a new libGearman Client instances and configures the
+	 * servers that it should connect to.
+	 *
+	 * @return bool True or false if successful
+	 */
+	public function register() {
+		$client = $this->get_gearman_client();
+
+		if ( $client !== false ) {
+			$servers = $this->get_servers();
+
+			if ( empty( $servers ) ) {
+				return $client->addServer();
+			} else {
+				return $client->addServers( implode( ',', $servers ) );
+			}
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Adds a Job to the libGearman Client's Queue.
+	 *
+	 * @param string $hook The action hook name for the job
+	 * @param array $args Optional arguments for the job
+	 * @param string $priority Optional priority of the job
+	 * @return bool true or false depending on the Client
+	 */
+	public function add( $hook, $args = array(), $priority = 'normal' ) {
+		$job_data = array(
+			'hook'    => $hook,
+			'args'    => $args,
+			'blog_id' => $this->get_blog_id(),
+		);
+
+		$client = $this->get_gearman_client();
+
+		if ( $client !== false ) {
+			$payload  = json_encode( $job_data );
+			$method   = $this->get_background_method( $priority );
+			$group    = $this->get_async_group();
+			$callable = array( $client, $method );
+
+			return call_user_func( $callable, $group, $payload );
+		} else {
+			return false;
+		}
+	}
+
+	/* Helpers */
+	/**
+	 * Returns the libGearman function to use based on the specified
+	 * priority.
+	 *
+	 * @param string $priority low, normal or high
+	 * @return string The corresponding method name
+	 */
+	function get_background_method( $priority ) {
+		switch( strtolower( $priority ) ) {
+			case 'high':
+				$method = 'doHighBackground';
+				break;
+
+			case 'low':
+				$method = 'doLowBackground';
+				break;
+
+			case 'normal':
+			default:
+				$method = 'doBackground';
+				break;
+		}
+
+		return $method;
+	}
+
+	/**
+	 * The Function Group used to split libGearman functions on a
+	 * multi-network install.
+	 *
+	 * @return string The prefixed group name
+	 */
+	function get_async_group() {
+		$key = '';
+
+		if ( defined( 'WP_ASYNC_TASK_SALT' ) ) {
+			$key .= WP_ASYNC_TASK_SALT . ':';
+		}
+
+		$key .= 'WP_Async_Task';
+
+		return $key;
+	}
+
+	/**
+	 * The Gearman Servers to connect to as defined in wp-config.php.
+	 *
+	 * If absent the default server will be used.
+	 *
+	 * @return array The list of servers for this Worker.
+	 */
+	function get_servers() {
+		if ( is_null( $this->gearman_servers ) ) {
+			global $gearman_servers;
+
+			if ( ! empty( $gearman_servers ) ) {
+				$this->gearman_servers = $gearman_servers;
+			} else {
+				$this->gearman_servers = array();
+			}
+		}
+
+		return $this->gearman_servers;
+	}
+
+	/**
+	 * Builds the libGearman Client Instance if the extension is
+	 * installed. Once created returns the previous instance without
+	 * reinitialization.
+	 *
+	 * @return GearmanClient|false An instance of GearmanClient
+	 */
+	function get_gearman_client() {
+		if ( is_null( $this->gearman_client ) ) {
+			if ( class_exists( '\GearmanClient' ) ) {
+				$this->gearman_client = new \GearmanClient();
+			} else {
+				$this->gearman_client = false;
+			}
+		}
+
+		return $this->gearman_client;
+	}
+
+	/**
+	 * Caches and returns the current blog id for adding to the Job meta
+	 * data. False if not a multisite install.
+	 *
+	 * @return int|false The current blog ids id.
+	 */
+	function get_blog_id() {
+		if ( is_null( $this->blog_id ) ) {
+			if ( defined( 'is_multisite' ) && is_multisite() ) {
+				$this->blog_id = get_current_blog_id();
+			} else {
+				$this->blog_id = false;
+			}
+		}
+
+		return $this->blog_id;
+	}
+
+}

--- a/includes/WpGears/Gearman/Client.php
+++ b/includes/WpGears/Gearman/Client.php
@@ -37,7 +37,6 @@ class Client extends BaseClient {
 
 		if ( $client !== false ) {
 			$servers = $this->get_servers();
-			var_dump( $client );
 
 			if ( empty( $servers ) ) {
 				return $client->addServer();

--- a/includes/WpGears/Gearman/Worker.php
+++ b/includes/WpGears/Gearman/Worker.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace WpGears\Gearman;
+
+use WpGears\Worker as BaseWorker;
+
+/**
+ * The Gearman Worker uses the libGearman API to execute Jobs in the
+ * Gearman queue. The servers that the Worker should connect to are
+ * configured as part of the initialization.
+ *
+ */
+class Worker extends BaseWorker {
+
+	/**
+	 * @var GearmanWorker The libGearman Worker instance
+	 */
+	public $gearman_worker;
+
+	/**
+	 * @var array The list of Gearman servers.
+	 */
+	public $gearman_servers;
+
+	/**
+	 * Creates a Gearman Worker and initializes the servers it should
+	 * connect to. The callback that will execute a job's hook is also setup here.
+	 *
+	 * @return bool True if operation was successful else false.
+	 */
+	public function register() {
+		$worker = $this->get_gearman_worker();
+
+		if ( $worker !== false ) {
+			$servers  = $this->get_servers();
+			$group    = $this->get_async_group();
+			$callable = array( $this, 'do_job' );
+
+
+			if ( empty( $servers ) ) {
+				$worker->addServer();
+			} else {
+				$worker->addServers( implode( ',', $servers ) );
+			}
+
+			return $worker->addFunction( $group, $callable );
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Pulls a job from the Gearman Queue and tries to execute it.
+	 * Errors are logged if the Job failed to execute.
+	 *
+	 * @return bool True if the job could be executed, else false
+	 */
+	public function work() {
+		$worker = $this->get_gearman_worker();
+
+		try {
+			$result = $worker->work();
+		} catch ( \Exception $e ) {
+			if ( ! defined( 'PHPUNIT_RUNNER' ) ) {
+				error_log( 'GearmanWorker->work failed: ' . $e->getMessage() );
+			}
+			$result = false;
+		}
+
+		return $result;
+	}
+
+	/* Helpers */
+	/**
+	 * Executes a Job pulled from Gearman. On a multisite instance
+	 * it switches to the target site before executing the job. And the
+	 * site is restored once executing is finished.
+	 *
+	 * The job data contains,
+	 *
+	 * 1. hook - The name of the target hook to execute
+	 * 2. args - Optional arguments to pass to the target hook
+	 * 3. blog_id - Optional blog on a multisite to switch to, before execution
+	 *
+	 * Actions are fired before and after execution of the target hook.
+	 *
+	 * Eg:- for the action 'foo' The order of execution of actions is,
+	 *
+	 * 1. wp_async_task_before_job
+	 * 2. wp_async_task_before_job_foo
+	 * 3. foo
+	 * 4. wp_async_task_after_job
+	 * 5. wp_async_task_after_job_foo
+	 *
+	 * @param array $job The job object data.
+	 * @return bool True or false based on the status of execution
+	 */
+	function do_job( $job ) {
+		$switched = false;
+
+		try {
+			$job_data = json_decode( $job->workload(), true );
+			$hook     = $job_data['hook'];
+			$args     = $job_data['args'];
+
+			if ( function_exists( 'is_multisite' ) && is_multisite() && $job_data['blog_id'] ) {
+				$blog_id = $job_data['blog_id'];
+
+				if ( get_current_blog_id() !== $blog_id ) {
+					switch_to_blog( $blog_id );
+					$switched = true;
+				} else {
+					$switched = false;
+				}
+			} else {
+				$switched = false;
+			}
+
+			do_action( 'wp_async_task_before_job', $hook );
+			do_action( 'wp_async_task_before_job_' . $hook );
+
+			do_action( $hook, $args );
+
+			do_action( 'wp_async_task_after_job', $hook );
+			do_action( 'wp_async_task_after_job_' . $hook );
+
+			$result = true;
+		} catch ( \Exception $e ) {
+			error_log(
+				'GearmanWorker->do_job failed: ' . $e->getMessage()
+			);
+			$result = false;
+		}
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * The Function Group used to split libGearman functions on a
+	 * multi-network install.
+	 *
+	 * @return string The prefixed group name
+	 */
+	function get_async_group() {
+		$key = '';
+
+		if ( defined( 'WP_ASYNC_TASK_SALT' ) ) {
+			$key .= WP_ASYNC_TASK_SALT . ':';
+		}
+
+		$key .= 'WP_Async_Task';
+
+		return $key;
+	}
+
+	/**
+	 * The Gearman Servers to connect to as defined in wp-config.php.
+	 *
+	 * If absent the default server will be used.
+	 *
+	 * @return array The list of servers for this Worker.
+	 */
+	function get_servers() {
+		if ( is_null( $this->gearman_servers ) ) {
+			global $gearman_servers;
+
+			if ( ! empty( $gearman_servers ) ) {
+				$this->gearman_servers = $gearman_servers;
+			} else {
+				$this->gearman_servers = array();
+			}
+		}
+
+		return $this->gearman_servers;
+	}
+
+	/**
+	 * Builds the libGearman Worker Instance if the extension is
+	 * installed. Once created returns the previous instance without
+	 * reinitialization.
+	 *
+	 * @return GearmanWorker|false An instance of GearmanWorker
+	 */
+	function get_gearman_worker() {
+		if ( is_null( $this->gearman_worker ) ) {
+			if ( class_exists( '\GearmanWorker' ) ) {
+				$this->gearman_worker = new \GearmanWorker();
+			} else {
+				$this->gearman_worker = false;
+			}
+		}
+
+		return $this->gearman_worker;
+	}
+}

--- a/includes/WpGears/Plugin.php
+++ b/includes/WpGears/Plugin.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace WpGears;
+
+/**
+ * The main WpGears Plugin object. It creates a client and worker object
+ * based the current configuration.
+ *
+ * When run in Client mode it will allow adding new jobs to the Queue.
+ *
+ * When run in worker mode it will execute jobs on the Queue. Worker
+ * mode also allows adding new jobs to the queue just like Mlient mode.
+ */
+class Plugin {
+
+	/**
+	 * @var Plugin Single instance of the plugin
+	 */
+	static public $instance;
+
+	/**
+	 * Returns the singleton instance of the Plugin. Creates the
+	 * instance if it is absent.
+	 *
+	 * @return Plugin instance of Plugin
+	 */
+	static public function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Plugin();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @var \WpGears\Client The Client object used to enqueue jobs
+	 */
+	public $client;
+
+	/**
+	 * @var \WpGears\Worker The Worker object used to execute jobs
+	 */
+	public $worker;
+
+	/**
+	 * @var string Configuration constants are prefixed by WP_GEARS by default.
+	 * ;w
+	 * Eg:- WP_GEARS_JOBS_PER_WORKER
+	 */
+	public $config_prefix = 'WP_GEARS';
+
+	/**
+	 * @var int Number of jobs to execute per worker, Default 1
+	 */
+	public $jobs_per_worker;
+
+	/** @var string Custom worker class */
+	public $worker_class;
+
+	/** @var Custom client class */
+	public $client_class;
+
+	/*
+	 * @var bool Indicates if the plugin executed a job.
+	 *
+	 * Only one run is allowed.
+	 */
+	public $did_run    = false;
+
+	/*
+	 * @var bool Indicates if the plugin was enabled. The Plugin can only be
+	 * enabled once
+	 */
+	public $did_enable = false;
+
+	/**
+	 * Enables the plugin by registering it's clients and workers.
+	 * Ignored if already enabled
+	 */
+	public function enable() {
+		if ( ! $this->did_enable ) {
+			$this->get_client()->register();
+			$this->get_worker()->register();
+
+			$this->did_enable = true;
+		}
+	}
+
+	/**
+	 * Starts processing jobs in the Worker.
+	 *
+	 * Only one run is permitted.
+	 *
+	 * @return int The exit status code (only for PHPUnit)
+	 */
+	public function run() {
+		if ( $this->did_run ) {
+			return false;
+		}
+
+		$this->did_run = true;
+
+		return $this->work();
+	}
+
+	/**
+	 * Executes jobs on the current Worker. A Worker will taken up
+	 * only one job by default. If WP_GEARS_JOBS_PER_WORKER is defined
+	 * that many jobs will be executed before it exits.
+	 *
+	 * This method will exit with the result code based on
+	 * success/failure of executing the job.
+	 *
+	 * @return int 0 for success and 1 for failure
+	 */
+	public function work() {
+		for ( $i = 0; $i < $this->get_jobs_per_worker(); $i++ ) {
+			$result      = $this->get_worker()->work();
+			$result_code = $result ? 0 : 1;
+		}
+
+		return $this->quit( $result_code );
+	}
+
+	/**
+	 * Adds a new job to the Client with the specified arguments and
+	 * priority.
+	 *
+	 * @param string $hook The action hook name for the job
+	 * @param array $args Optional arguments for the job
+	 * @param string $priority Optional priority of the job
+	 * @return bool true or false depending on the Client
+	 */
+	public function add( $hook, $args = array(), $priority = 'normal' ) {
+		return $this->get_client()->add(
+			$hook, $args, $priority
+		);
+	}
+
+	/* Helpers */
+	/**
+	 * Returns the Client object used to add jobs. Creates the instance
+	 * of the client lazily.
+	 *
+	 * @return \WpGears\Client The client instance
+	 */
+	function get_client() {
+		if ( is_null( $this->client ) ) {
+			$this->client = $this->build_client();
+		}
+
+		return $this->client;
+	}
+
+	/**
+	 * Returns the Worker object used to execute jobs. Creates the instance
+	 * of the worker lazily.
+	 *
+	 * @param \WpGears\Worker The worker instance
+	 */
+	function get_worker() {
+		if ( is_null( $this->worker ) ) {
+			$this->worker = $this->build_worker();
+		}
+
+		return $this->worker;
+	}
+
+	/**
+	 * Conditionally builds a new Client object. If the constant
+	 * WP_GEARS_CLIENT_CLASS is defined it will return an instance of that
+	 * class.
+	 *
+	 * By default it will detect if Gearman is present and return the
+	 * Gearman Client else fallback to the Cron Client.
+	 *
+	 * @return \WpGears\Client New instance of the Client
+	 */
+	function build_client() {
+		if ( ! $this->has_config( 'CLIENT_CLASS' ) ) {
+			if ( class_exists( '\GearmanClient' ) ) {
+				return new \WpGears\Gearman\Client();
+			} else {
+				return new \WpGears\Cron\Client();
+			}
+		} else {
+			$klass = $this->get_config( 'CLIENT_CLASS' );
+			return new $klass();
+		}
+	}
+
+	/**
+	 * Conditionally builds a new Worker object. If the constant
+	 * WP_GEARS_WORKER_CLASS is defined it will return an instance of
+	 * that class.
+	 *
+	 * By default it will detect if Gearman is present and return the
+	 * Gearman Worker else fallback to the Cron Worker.
+	 *
+	 * @return \WpGears\Worker New instance of the Worker
+	 */
+	function build_worker() {
+		if ( ! $this->has_config( 'WORKER_CLASS' ) ) {
+			if ( class_exists( '\GearmanWorker' ) ) {
+				return new \WpGears\Gearman\Worker();
+			} else {
+				return new \WpGears\Cron\Worker();
+			}
+		} else {
+			$klass = $this->get_config( 'WORKER_CLASS' );
+			return new $klass();
+		}
+	}
+
+	/**
+	 * Returns the jobs to execute per worker instance
+	 *
+	 * @return int Defaults to 1
+	 */
+	function get_jobs_per_worker() {
+		return $this->get_config(
+			'JOBS_PER_WORKER', 1
+		);
+	}
+
+	/**
+	 * Helper to pickup config options from Constants with fallbacks.
+	 *
+	 * Order of lookup is,
+	 *
+	 * 1. Local Property
+	 * 2. Constant of that name
+	 * 3. Default specified
+	 *
+	 * Eg:- get_config( 'FOO', 'abc', 'MY' )
+	 *
+	 * will look for,
+	 *
+	 * 1. Local Property $this->my_foo
+	 * 2. Constant MY_FOO
+	 * 3. Defaualt ie:- abc
+	 *
+	 * @param string $constant Name of constant to lookup
+	 * @param string $default Optional default
+	 * @param string $config_prefix Optional config prefix, Default is WP_GEARS
+	 * @return mixed The value of the config
+	 */
+	function get_config( $constant, $default = '', $config_prefix = '' ) {
+		$variable      = strtolower( $constant );
+		$config_prefix = empty( $config_prefix ) ? $this->config_prefix : $config_prefix;
+		$constant      = $config_prefix . '_' . $constant;
+
+		if ( property_exists( $this, $variable ) ) {
+			if ( is_null( $this->$variable ) ) {
+				if ( defined( $constant ) ) {
+					$this->$variable = constant( $constant );
+				} else {
+					$this->$variable = $default;
+				}
+			}
+
+			return $this->$variable;
+		} else {
+			throw new \Exception(
+				"Fatal Error - Public Var($variable) not declared"
+			);
+		}
+	}
+
+	/**
+	 * Checks if a config option is defined. Empty strings are treated
+	 * as an undefined config option.
+	 *
+	 * @param string $constant The name of the constant
+	 * @return bool True or false depending on whether the config is present
+	 */
+	function has_config( $constant ) {
+		return ! empty( $this->get_config( $constant ) );
+	}
+
+	/**
+	 * Helper to quit with a status code. When running under PHPUnit it
+	 * returns the status_code instead of exiting immediately.
+	 *
+	 * @param int $status_code The status between 0-255 to quit with.
+	 */
+	function quit( $status_code ) {
+		if ( ! defined( 'PHPUNIT_RUNNER' ) ) {
+			exit( $status_code );
+		} else {
+			return $status_code;
+		}
+	}
+
+	/**
+	 * Returns the path to the wp-load.php file.
+	 *
+	 * @return string Path to the wp-load.php file
+	 */
+	function get_wp_load() {
+		$wp_dir  = dirname( $_SERVER['SCRIPT_FILENAME'] ) ;
+		return $wp_dir . '/wp-load.php';
+	}
+
+	/**
+	 * Tries to load WordPress using wp-load.php. If loading fails an
+	 * error message is logged and the Script will exit immediately with
+	 * a status code of 1.
+	 */
+	function load_wordpress() {
+		$wp_load = $this->get_wp_load();
+
+		if ( file_exists( $wp_load ) ) {
+			require_once( $wp_load );
+		} else {
+			error_log(
+				"WP Gears Fatal Error - Cannot find wp-load.php( $wp_load )"
+			);
+
+			return $this->quit( 1 );
+		}
+	}
+
+}

--- a/includes/WpGears/Plugin.php
+++ b/includes/WpGears/Plugin.php
@@ -275,7 +275,8 @@ class Plugin {
 	 * @return bool True or false depending on whether the config is present
 	 */
 	function has_config( $constant ) {
-		return ! empty( $this->get_config( $constant ) );
+		$value = $this->get_config( $constant );
+		return ! empty( $value );
 	}
 
 	/**

--- a/includes/WpGears/Worker.php
+++ b/includes/WpGears/Worker.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WpGears;
+
+/**
+ * Workers are responsible for executing jobs. They may perform any
+ * implementation specific initialization if needed.
+ */
+abstract class Worker {
+
+	/**
+	 * Any implementation specific initialization goes here.
+	 *
+	 * @return bool True or false based on whether the Worker was registered
+	 */
+	abstract public function register();
+
+	/**
+	 * Start performing work here. The Worker may perform the work
+	 * immediately here or trigger actions to perform it later.
+	 *
+	 * @return bool True or false if the job could be done.
+	 */
+	abstract public function work();
+
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit colors="true" bootstrap="tests/bootstrap.php">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/portkey.json
+++ b/portkey.json
@@ -1,0 +1,10 @@
+{
+  "includes/WpGears/*.php": {
+    "type": "plugin",
+    "test": "tests/WpGears/%sTest.php"
+  },
+  "tests/WpGears/*Test.php": {
+    "type": "test",
+    "alternate": "includes/WpGears/%s.php"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,22 @@ add_action( 'myplugin_update_option', 'myplugin_update_option_callback' );
 ```
 Once a worker is free, and runs the above task, you'd have an option called "my-option-name" in the options table, with a value of "myvalue", since "myvalue" was passed in via the ```$args```
 
+## Customization
+
+The following constants can be used to customize the behaviour of WP Gears.
+
+1. `WP_GEARS_JOBS_PER_WORKER` - The number of jobs to execute per Worker,
+   default is 1. Running multiple jobs per worker will reduce the number
+   workers spawned, and can significantly boost performance. However too
+   large a value will cause issues if you have memory leaks. Use with
+   caution.
+
+2. `WP_GEARS_CLIENT_CLASS` - You can also alter the Client class used to
+   send jobs to Gearman. It should match the interface of
+   `\WpGears\Client`.
+
+3. `WP_GEARS_WORKER_CLASS` - Similarly you can alter the Worker class used
+   to execute jobs. It should match the interface of `\WpGears\Worker`.
 
 ## Issues
 

--- a/tests/WpGears/Cron/ClientTest.php
+++ b/tests/WpGears/Cron/ClientTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WpGears\Cron;
+
+class CronClientTest extends \WP_UnitTestCase {
+
+	public $client;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->client = new Client();
+	}
+
+	function test_it_can_be_registered() {
+		$actual = $this->client->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_creates_cron_event_on_add() {
+		$actual = $this->client->add( 'cron_action_a' );
+		$this->assertTrue( $actual );
+
+		$next_event = wp_next_scheduled( 'cron_action_a', array() );
+		$this->assertEquals( time(), $next_event );
+	}
+
+}

--- a/tests/WpGears/Cron/WorkerTest.php
+++ b/tests/WpGears/Cron/WorkerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WpGears\Cron;
+
+class CronWorkerTest extends \WP_UnitTestCase {
+
+	public $worker;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->worker = new Worker();
+	}
+
+	function test_it_can_be_registered() {
+		$actual = $this->worker->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_can_start_working_on_work() {
+		$actual = $this->worker->work();
+		$this->assertTrue( $actual );
+	}
+
+}

--- a/tests/WpGears/Gearman/ClientTest.php
+++ b/tests/WpGears/Gearman/ClientTest.php
@@ -135,7 +135,7 @@ class GearmanClientTest extends \WP_UnitTestCase {
 		$payload = array(
 			'hook'    => 'action_b',
 			'args'    => array(),
-			'blog_id' => is_multisite() ? get_current_blog_id() : false,
+			'blog_id' => function_exists( 'is_multisite' ) && is_multisite() ? get_current_blog_id() : false,
 		);
 
 		$group = defined( 'WP_ASYNC_TASK_SALT' ) ? WP_ASYNC_TASK_SALT . ':WP_Async_Task' : '';

--- a/tests/WpGears/Gearman/ClientTest.php
+++ b/tests/WpGears/Gearman/ClientTest.php
@@ -81,7 +81,7 @@ class GearmanClientTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_has_a_blog_id_if_on_multisite() {
-		if ( defined( 'is_multisite' ) && is_multisite() ) {
+		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 			$actual = $this->client->get_blog_id();
 			$this->assertEquals( 1, $actual );
 		} else {
@@ -90,7 +90,7 @@ class GearmanClientTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_does_not_have_blog_id_on_single_site() {
-		if ( ! ( defined( 'is_multisite' ) && is_multisite() ) ) {
+		if ( ! ( function_exists( 'is_multisite' ) && is_multisite() ) ) {
 			$actual = $this->client->get_blog_id();
 			$this->assertFalse( $actual );
 		} else {

--- a/tests/WpGears/Gearman/ClientTest.php
+++ b/tests/WpGears/Gearman/ClientTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace WpGears\Gearman;
+
+class GearmanClientTest extends \WP_UnitTestCase {
+
+	public $client;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->client = new Client();
+	}
+
+	function tearDown() {
+		\Mockery::close();
+	}
+
+	function test_it_knows_if_no_gearman_servers_are_defined() {
+		$actual = $this->client->get_servers();
+		$this->assertEmpty( $actual );
+	}
+
+	function test_it_knows_if_gearman_servers_are_defined() {
+		global $gearman_servers;
+		$gearman_servers = array(
+			'192.168.1.10:5555',
+		);
+
+		$actual = $this->client->get_servers();
+		$this->assertEquals(
+			array( '192.168.1.10:5555' ), $actual
+		);
+
+		unset( $gearman_servers );
+	}
+
+	function test_it_can_create_a_gearman_client_if_configured() {
+		if ( class_exists( '\GearmanClient' ) ) {
+			$actual = $this->client->get_gearman_client();
+			$this->assertInstanceOf(
+				'\GearmanClient', $actual
+			);
+		} else {
+			//$this->markTestSkipped();
+		}
+	}
+
+	function test_it_will_not_register_if_no_valid_gearman_client() {
+		$this->client->gearman_client = false;
+		$actual = $this->client->register();
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_add_default_server_to_client_if_not_defined() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'addServer' )
+			->with()
+			->andReturn( true )
+			->getMock();
+
+		$this->client->gearman_client = $mock;
+		$actual = $this->client->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_will_add_multiple_servers_to_client_if_defined() {
+		$this->client->gearman_servers = array(
+			'localhost:5554', '127.0.0.1:5555',
+		);
+
+		$mock = \Mockery::mock()
+			->shouldReceive( 'addServers' )
+			->with( implode( ',', $this->client->gearman_servers ) )
+			->andReturn( true )
+			->getMock();
+
+		$this->client->gearman_client = $mock;
+		$actual = $this->client->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_has_a_blog_id_if_on_multisite() {
+		if ( defined( 'is_multisite' ) && is_multisite() ) {
+			$actual = $this->client->get_blog_id();
+			$this->assertEquals( 1, $actual );
+		} else {
+			//$this->markTestSkipped();
+		}
+	}
+
+	function test_it_does_not_have_blog_id_on_single_site() {
+		if ( ! ( defined( 'is_multisite' ) && is_multisite() ) ) {
+			$actual = $this->client->get_blog_id();
+			$this->assertFalse( $actual );
+		} else {
+			//$this->markTestSkipped();
+		}
+	}
+
+	function test_it_has_an_async_group() {
+		if ( defined( 'WP_ASYNC_TASK_SALT' ) ) {
+			$expected = WP_ASYNC_TASK_SALT . ':WP_Async_Task';
+		} else {
+			define( 'WP_ASYNC_TASK_SALT', 'foo' );
+			$expected = 'foo:WP_Async_Task';
+		}
+
+		$actual = $this->client->get_async_group();
+		$this->assertEquals( $expected, $actual );
+	}
+
+	function test_it_knows_when_to_use_high_background_method() {
+		$actual = $this->client->get_background_method( 'high' );
+		$this->assertEquals( 'doHighBackground', $actual );
+	}
+
+	function test_it_knows_when_to_use_low_background_method() {
+		$actual = $this->client->get_background_method( 'low' );
+		$this->assertEquals( 'doLowBackground', $actual );
+	}
+
+	function test_it_knows_when_to_use_normal_background_method() {
+		$actual = $this->client->get_background_method( 'normal' );
+		$this->assertEquals( 'doBackground', $actual );
+	}
+
+	function test_it_will_not_add_hook_to_gearman_if_gearman_is_absent() {
+		$this->client->gearman_client = false;
+		$actual = $this->client->add( 'action_a' );
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_add_hook_to_gearman_client_if_present() {
+		$payload = array(
+			'hook'    => 'action_b',
+			'args'    => array(),
+			'blog_id' => is_multisite() ? get_current_blog_id() : false,
+		);
+
+		$group = defined( 'WP_ASYNC_TASK_SALT' ) ? WP_ASYNC_TASK_SALT . ':WP_Async_Task' : '';
+		$mock = \Mockery::mock()
+			->shouldReceive('doBackground')
+			->with( $group, json_encode( $payload ) )
+			->andReturn( true )
+			->getMock();
+
+		$this->client->gearman_client = $mock;
+		$actual = $this->client->add( 'action_b' );
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_will_add_hook_to_gearman_client_with_custom_arguments_and_priority() {
+		$payload = array(
+			'hook'    => 'action_c',
+			'args'    => array( 'a' => 1, 'b' => 2 ),
+			'blog_id' => is_multisite() ? get_current_blog_id() : false,
+		);
+
+		$group = defined( 'WP_ASYNC_TASK_SALT' ) ? WP_ASYNC_TASK_SALT . ':WP_Async_Task' : '';
+		$mock = \Mockery::mock()
+			->shouldReceive('doHighBackground')
+			->with( $group, json_encode( $payload ) )
+			->andReturn( true )
+			->getMock();
+
+		$this->client->gearman_client = $mock;
+		$actual = $this->client->add( 'action_b', $payload, 'high' );
+		$this->assertTrue( $actual );
+	}
+
+}

--- a/tests/WpGears/Gearman/WorkerTest.php
+++ b/tests/WpGears/Gearman/WorkerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace WpGears\Gearman;
+
+class GearmanWorkerTest extends \WP_UnitTestCase {
+
+	public $worker;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->worker = new Worker();
+	}
+
+	function tearDown() {
+		\Mockery::close();
+	}
+
+	function test_it_knows_if_no_gearman_servers_are_defined() {
+		$actual = $this->worker->get_servers();
+		$this->assertEmpty( $actual );
+	}
+
+	function test_it_knows_if_gearman_servers_are_defined() {
+		global $gearman_servers;
+		$gearman_servers = array(
+			'192.168.1.10:5555',
+		);
+
+		$actual = $this->worker->get_servers();
+		$this->assertEquals(
+			array( '192.168.1.10:5555' ), $actual
+		);
+
+		unset( $gearman_servers );
+	}
+
+	function test_it_can_create_a_gearman_worker_if_configured() {
+		if ( class_exists( '\GearmanWorker' ) ) {
+			$actual = $this->worker->get_gearman_worker();
+			$this->assertInstanceOf(
+				'\GearmanWorker', $actual
+			);
+		} else {
+			//$this->markTestSkipped();
+		}
+	}
+
+	function test_it_will_not_register_if_no_valid_gearman_worker() {
+		$this->worker->gearman_worker = false;
+		$actual = $this->worker->register();
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_add_default_server_to_worker_if_not_defined() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'addServer' )
+			->with()
+			->andReturn( true )
+			->shouldReceive( 'addFunction' )
+			->andReturn( true )
+			->getMock();
+
+		$this->worker->gearman_worker = $mock;
+		$actual = $this->worker->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_will_add_multiple_servers_to_worker_if_defined() {
+		$this->worker->gearman_servers = array(
+			'localhost:5554', '127.0.0.1:5555',
+		);
+
+		$mock = \Mockery::mock()
+			->shouldReceive( 'addServers' )
+			->with( implode( ',', $this->worker->gearman_servers ) )
+			->andReturn( true )
+			->shouldReceive( 'addFunction' )
+			->andReturn( true )
+			->getMock();
+
+		$this->worker->gearman_worker = $mock;
+		$actual = $this->worker->register();
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_will_not_fail_if_the_worker_failed_to_execute() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->andThrow( new \Exception( 'foo error' ) )
+			->getMock();
+
+		$this->worker->gearman_worker = $mock;
+		$actual = $this->worker->work();
+
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_start_the_gearman_worker_on_work() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->andReturn( true )
+			->getMock();
+
+		$this->worker->gearman_worker = $mock;
+		$actual = $this->worker->work();
+
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_can_execute_job_with_specified_arguments() {
+		$payload = array(
+			'hook' => 'action_d',
+			'args' => array( 'a' => 1, 'b' => 2 ),
+			'blog_id' => false,
+		);
+
+		$mock = \Mockery::mock()
+			->shouldReceive( 'workload' )
+			->with()
+			->andReturn( json_encode( $payload ) )
+			->getMock();
+
+		$action_mock = \Mockery::mock()
+			->shouldReceive()
+			->andReturn( 'foo' );
+
+		$self = $this;
+		$args = $payload['args'];
+
+		add_action( 'action_d', array( $this, 'did_action_d' ) );
+		add_action( 'wp_async_task_before_job', array( $this, 'did_before_job' ) );
+		add_action( 'wp_async_task_before_job_action_d', array( $this, 'did_before_action_d' ) );
+		add_action( 'wp_async_task_after_job', array( $this, 'did_after_job' ) );
+		add_action( 'wp_async_task_after_job_action_d', array( $this, 'did_after_action_d' ) );
+
+		$this->expected_args = $args;
+		$actual = $this->worker->do_job( $mock );
+
+		$this->assertTrue( $this->ran_action_d );
+		$this->assertTrue( $this->before_job );
+		$this->assertTrue( $this->did_before_action_d );
+		$this->assertTrue( $this->after_job );
+		$this->assertTrue( $this->did_after_action_d );
+	}
+
+	function did_action_d( $args ) {
+		$this->ran_action_d = true;
+		$this->assertEquals( $this->expected_args, $args );
+	}
+
+	function did_before_job() {
+		$this->before_job = true;
+	}
+
+	function did_after_job() {
+		$this->after_job = true;
+	}
+
+	function did_before_action_d() {
+		$this->did_before_action_d = true;
+	}
+
+	function did_after_action_d() {
+		$this->did_after_action_d = true;
+	}
+
+	function test_it_will_switch_to_target_blog_if_needed() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		$payload = array(
+			'hook' => 'action_e',
+			'args' => array( 'a' => 1, 'b' => 2 ),
+			'blog_id' => 1,
+		);
+
+		$mock = \Mockery::mock()
+			->shouldReceive( 'workload' )
+			->with()
+			->andReturn( json_encode( $payload ) )
+			->getMock();
+
+		$action_mock = \Mockery::mock()
+			->shouldReceive()
+			->andReturn( 'foo' );
+
+		$self = $this;
+		$args = $payload['args'];
+
+		add_action( 'action_e', array( $this, 'did_action_e' ) );
+
+		$actual = $this->worker->do_job( $mock );
+
+		$this->assertEquals( 1, $this->actual_site );
+	}
+
+	function did_action_e( $args ) {
+		$this->actual_site = get_current_blog_id();
+	}
+
+}

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace WpGears;
+
+class PluginTest extends \WP_UnitTestCase {
+
+	public $plugin;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->plugin = new Plugin();
+	}
+
+	function tearDown() {
+		\Mockery::close();
+	}
+
+	function test_it_has_a_singleton_instance() {
+		$instance1 = Plugin::get_instance();
+		$instance2 = Plugin::get_instance();
+
+		$this->assertSame( $instance1, $instance2 );
+	}
+
+	function test_it_does_not_recreate_client() {
+		$client1 = $this->plugin->get_client();
+		$client2 = $this->plugin->get_client();
+
+		$this->assertSame( $client1, $client2 );
+	}
+
+	function test_it_does_not_recreate_worker() {
+		$worker1 = $this->plugin->get_worker();
+		$worker2 = $this->plugin->get_worker();
+
+		$this->assertSame( $worker1, $worker2 );
+	}
+
+	function test_it_will_execute_one_job_per_worker_by_default() {
+		$actual = $this->plugin->get_jobs_per_worker();
+		$this->assertEquals( 1, $actual );
+	}
+
+	function test_it_will_execute_specified_jobs_per_worker() {
+		$this->plugin->config_prefix = 'A';
+		define( 'A_JOBS_PER_WORKER', 50 );
+
+		$actual = $this->plugin->get_jobs_per_worker();
+		$this->assertEquals( 50, $actual );
+	}
+
+	function test_it_will_use_a_custom_client_class_if_defined() {
+		$mock = \Mockery::mock( '\WpGears\Client' );
+		$this->plugin->config_prefix = 'B';
+		define( 'B_CLIENT_CLASS', get_class( $mock ) );
+
+		$actual = $this->plugin->build_client();
+		$this->assertInstanceOf( get_class( $mock ), $actual );
+	}
+
+	function test_it_will_use_a_custom_worker_class_if_defined() {
+		$mock = \Mockery::mock( '\WpGears\Worker' );
+		$this->plugin->config_prefix = 'C';
+		define( 'C_WORKER_CLASS', get_class( $mock ) );
+
+		$actual = $this->plugin->build_worker();
+		$this->assertInstanceOf( get_class( $mock ), $actual );
+	}
+
+	function test_it_will_build_a_gearman_client_if_gearman_is_present() {
+		if ( ! class_exists( '\GearmanClient' ) ) {
+			$mock = \Mockery::mock( 'alias:GearmanClient' );
+			$klass = get_class( $mock );
+		} else {
+			$klass = '\GearmanClient';
+		}
+
+		$actual = $this->plugin->build_client();
+		$this->assertInstanceOf(
+			'\WpGears\Gearman\Client', $actual
+		);
+	}
+
+	function test_it_will_build_a_gearman_worker_if_gearman_is_absent() {
+		if ( ! class_exists( '\GearmanWorker' ) ) {
+			$mock = \Mockery::mock( 'alias:GearmanWorker' );
+			$klass = get_class( $mock );
+		} else {
+			$klass = '\GearmanWorker';
+		}
+
+		$actual = $this->plugin->build_worker();
+		$this->assertInstanceOf(
+			'\WpGears\Gearman\Worker', $actual
+		);
+	}
+
+	function test_it_will_build_a_cron_client_if_gearman_is_missing() {
+		if ( ! class_exists( '\GearmanClient' ) ) {
+			$actual = $this->plugin->build_client();
+			$this->assertInstanceOf(
+				'\WpGears\Cron\Client', $actual
+			);
+		}
+	}
+
+	function test_it_will_build_a_cron_worker_if_gearman_is_missing() {
+		if ( ! class_exists( '\GearmanWorker' ) ) {
+			$actual = $this->plugin->build_worker();
+			$this->assertInstanceOf(
+				'\WpGears\Cron\Worker', $actual
+			);
+		}
+	}
+
+	function test_it_can_pass_jobs_to_client() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'add' )
+			->with( 'action_a', array( 1, 2, 3 ), 'high' )
+			->once()
+			->andReturn( true )
+			->getMock();
+
+		$this->plugin->client = $mock;
+		$actual = $this->plugin->add( 'action_a', array( 1, 2, 3 ), 'high' );
+		$this->assertTrue( $actual );
+	}
+
+	function test_it_will_execute_one_worker_and_exit_by_default() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->with()
+			->once()
+			->andReturn( true )
+			->getMock();
+
+		$this->plugin->worker = $mock;
+
+		$actual = $this->plugin->work();
+		$this->assertEquals( 0, $actual );
+	}
+
+	function test_it_will_return_1_exit_code_if_worker_failed() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->with()
+			->once()
+			->andReturn( false )
+			->getMock();
+
+		$this->plugin->worker = $mock;
+
+		$actual = $this->plugin->work();
+		$this->assertEquals( 1, $actual );
+	}
+
+	function test_it_will_execute_multiple_jobs_on_worker_if_specified() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->with()
+			->times( 10 )
+			->andReturn( true )
+			->getMock();
+
+		$this->plugin->worker = $mock;
+
+		$this->plugin->config_prefix = 'D';
+		define( 'D_JOBS_PER_WORKER', 10 );
+
+		$actual = $this->plugin->work();
+		$this->assertEquals( 0, $actual );
+	}
+
+	function test_it_will_build_client_and_worker_on_enabled() {
+		$this->plugin->enable();
+
+		$this->assertInstanceOf(
+			'\WpGears\Worker', $this->plugin->worker
+		);
+
+		$this->assertInstanceOf(
+			'\WpGears\Client', $this->plugin->client
+		);
+	}
+
+	function test_it_will_not_run_if_already_run() {
+		$this->plugin->did_run = true;
+		$actual = $this->plugin->run();
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_perform_a_job_on_run() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'work' )
+			->with()
+			->once()
+			->andReturn( true )
+			->getMock();
+
+		$this->plugin->worker = $mock;
+		$actual = $this->plugin->run();
+
+		$this->assertEquals( 0, $actual );
+	}
+
+	/* helpers */
+
+}

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -81,7 +81,7 @@ class PluginTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_will_build_a_gearman_worker_if_gearman_is_absent() {
-		if ( ! class_exists( '\GearmanWorker' ) ) {
+		if ( class_exists( '\GearmanWorker' ) ) {
 			$klass = '\GearmanWorker';
 			$actual = $this->plugin->build_worker();
 			$this->assertInstanceOf(

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -71,7 +71,7 @@ class PluginTest extends \WP_UnitTestCase {
 
 	function test_it_will_build_a_gearman_client_if_gearman_is_present() {
 		if ( ! class_exists( '\GearmanClient' ) ) {
-			$mock = \Mockery::mock( 'GearmanClient' );
+			$mock = \Mockery::mock( 'FakeGearmanClient' );
 			$klass = get_class( $mock );
 		} else {
 			$klass = '\GearmanClient';
@@ -85,7 +85,7 @@ class PluginTest extends \WP_UnitTestCase {
 
 	function test_it_will_build_a_gearman_worker_if_gearman_is_absent() {
 		if ( ! class_exists( '\GearmanWorker' ) ) {
-			$mock = \Mockery::mock( 'GearmanWorker' );
+			$mock = \Mockery::mock( 'FakeGearmanWorker' );
 			$klass = get_class( $mock );
 		} else {
 			$klass = '\GearmanWorker';

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -174,6 +174,7 @@ class PluginTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_will_build_client_and_worker_on_enabled() {
+		var_dump( $this->plugin->client );
 		$this->plugin->enable();
 
 		$this->assertInstanceOf(

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -70,31 +70,24 @@ class PluginTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_will_build_a_gearman_client_if_gearman_is_present() {
-		if ( ! class_exists( '\GearmanClient' ) ) {
-			$mock = \Mockery::mock( 'FakeGearmanClient' );
-			$klass = get_class( $mock );
-		} else {
+		if ( class_exists( '\GearmanClient' ) ) {
 			$klass = '\GearmanClient';
-		}
+			$actual = $this->plugin->build_client();
 
-		$actual = $this->plugin->build_client();
-		$this->assertInstanceOf(
-			'\WpGears\Gearman\Client', $actual
-		);
+			$this->assertInstanceOf(
+				'\WpGears\Gearman\Client', $actual
+			);
+		}
 	}
 
 	function test_it_will_build_a_gearman_worker_if_gearman_is_absent() {
 		if ( ! class_exists( '\GearmanWorker' ) ) {
-			$mock = \Mockery::mock( 'FakeGearmanWorker' );
-			$klass = get_class( $mock );
-		} else {
 			$klass = '\GearmanWorker';
+			$actual = $this->plugin->build_worker();
+			$this->assertInstanceOf(
+				'\WpGears\Gearman\Worker', $actual
+			);
 		}
-
-		$actual = $this->plugin->build_worker();
-		$this->assertInstanceOf(
-			'\WpGears\Gearman\Worker', $actual
-		);
 	}
 
 	function test_it_will_build_a_cron_client_if_gearman_is_missing() {

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -10,6 +10,7 @@ class PluginTest extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->plugin = new Plugin();
+		$this->config_prefix = 'A' . uniqid();
 	}
 
 	function tearDown() {

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -10,7 +10,7 @@ class PluginTest extends \WP_UnitTestCase {
 		parent::setUp();
 
 		$this->plugin = new Plugin();
-		$this->config_prefix = 'A' . uniqid();
+		$this->plugin->config_prefix = 'A' . uniqid();
 	}
 
 	function tearDown() {

--- a/tests/WpGears/PluginTest.php
+++ b/tests/WpGears/PluginTest.php
@@ -71,7 +71,7 @@ class PluginTest extends \WP_UnitTestCase {
 
 	function test_it_will_build_a_gearman_client_if_gearman_is_present() {
 		if ( ! class_exists( '\GearmanClient' ) ) {
-			$mock = \Mockery::mock( 'alias:GearmanClient' );
+			$mock = \Mockery::mock( 'GearmanClient' );
 			$klass = get_class( $mock );
 		} else {
 			$klass = '\GearmanClient';
@@ -85,7 +85,7 @@ class PluginTest extends \WP_UnitTestCase {
 
 	function test_it_will_build_a_gearman_worker_if_gearman_is_absent() {
 		if ( ! class_exists( '\GearmanWorker' ) ) {
-			$mock = \Mockery::mock( 'alias:GearmanWorker' );
+			$mock = \Mockery::mock( 'GearmanWorker' );
 			$klass = get_class( $mock );
 		} else {
 			$klass = '\GearmanWorker';
@@ -174,7 +174,6 @@ class PluginTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_will_build_client_and_worker_on_enabled() {
-		var_dump( $this->plugin->client );
 		$this->plugin->enable();
 
 		$this->assertInstanceOf(

--- a/tests/WpGearsRunnerTest.php
+++ b/tests/WpGearsRunnerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class WpGearsRunnerTest extends \WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		require_once( __DIR__ . '/../wp-gears-runner.php' );
+	}
+
+	function tearDown() {
+		\Mockery::close();
+	}
+
+	function test_it_has_a_custom_autoloader() {
+		$this->assertTrue( function_exists( 'wp_gears_autoload' ) );
+	}
+
+	function test_it_can_autoload_classes() {
+		spl_autoload_register( 'wp_gears_autoload', false, true );
+
+		$klass = new \WpGears\Plugin();
+		$this->assertInstanceOf( '\WpGears\Plugin', $klass );
+	}
+
+	function test_it_will_execute_a_job_on_run() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'register' )
+			->andReturn( true )
+			->shouldReceive( 'work' )
+			->with()
+			->once()
+			->andReturn( true )
+			->getMock();
+
+		$plugin = \WpGears\Plugin::get_instance();
+		$plugin->worker = $mock;
+
+		$actual = wp_gears_runner();
+		$this->assertEquals( 0, $actual );
+	}
+
+}

--- a/tests/WpGearsRunnerTest.php
+++ b/tests/WpGearsRunnerTest.php
@@ -34,6 +34,7 @@ class WpGearsRunnerTest extends \WP_UnitTestCase {
 			->getMock();
 
 		$plugin = \WpGears\Plugin::get_instance();
+		$plugin->config_prefix = 'B' . uniqid();
 		$plugin->worker = $mock;
 
 		$actual = wp_gears_runner();

--- a/tests/WpGearsTest.php
+++ b/tests/WpGearsTest.php
@@ -35,6 +35,7 @@ class WpGearsTest extends \WP_UnitTestCase {
 			->getMock();
 
 		$plugin = \WpGears\Plugin::get_instance();
+		$plugin->config_prefix = 'C' . uniqid();
 		$plugin->client = $mock;
 
 		$actual = wp_async_task_add( 'action_b', array( 1, 2, 3 ), 'low' );

--- a/tests/WpGearsTest.php
+++ b/tests/WpGearsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class WpGearsTest extends \WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		require_once( __DIR__ . '/../wp-gears.php' );
+	}
+
+	function tearDown() {
+		\Mockery::close();
+	}
+
+	function test_it_has_a_custom_autoloader() {
+		$this->assertTrue( function_exists( 'wp_gears_autoload' ) );
+	}
+
+	function test_it_can_initialize_the_plugin() {
+		wp_async_task_init();
+
+		$plugin = \WpGears\Plugin::get_instance();
+		$this->assertTrue( $plugin->did_enable );
+	}
+
+	function test_it_can_add_job_to_client_object() {
+		$mock = \Mockery::mock()
+			->shouldReceive( 'register' )
+			->atMost(1)
+			->andReturn( true )
+			->shouldReceive( 'add' )
+			->with( 'action_b', array( 1, 2, 3 ), 'low' )
+			->once()
+			->andReturn( true )
+			->getMock();
+
+		$plugin = \WpGears\Plugin::get_instance();
+		$plugin->client = $mock;
+
+		$actual = wp_async_task_add( 'action_b', array( 1, 2, 3 ), 'low' );
+		$this->assertTrue( $actual );
+	}
+
+}

--- a/tests/WpGearsTest.php
+++ b/tests/WpGearsTest.php
@@ -27,6 +27,8 @@ class WpGearsTest extends \WP_UnitTestCase {
 		$mock = \Mockery::mock()
 			->shouldReceive( 'register' )
 			->atMost(1)
+			->shouldReceive( 'addServer' )
+			->atMost(1)
 			->andReturn( true )
 			->shouldReceive( 'add' )
 			->with( 'action_b', array( 1, 2, 3 ), 'low' )

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$_tests_dir = getenv('WP_TESTS_DIR');
+if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+  require dirname(__FILE__) . '/../vendor/autoload.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+
+define('PHPUNIT_RUNNER', true);


### PR DESCRIPTION
Hi Chris,

This is a refactoring of the Plugin into a main plugin and 2 objects, Client & Worker. The client is responsible for adding jobs to the queue. And the Worker picks up jobs and executes them. There are  2 concrete implementations. The Gearman one uses the libGearman API as before. And the Cron implementation is using `wp_schedule_single_event` as before.

The changes are API compatible with the v1.0. One change I've made is to use `class_exists` instead of the `ping`. The ping implementation could potentially lead to performance issues in scenarios where Gearman is down or not configured. Those jobs would get added to Cron and end up executing on the front-end with the Cron fallback.

New Features
1. HHVM Compatibility - Now runs on HHVM using WP-Cron. Previously it would die with an error message.
2. WP_GEARS_JOBS_PER_WORKER - Customize the number of jobs one worker runs. Improves performance for use cases with large number of workers. 
3. WP_GEARS_CLIENT_CLASS & WP_GEARS_SERVER_CLASS - Customize the underlying Client and Worker objects. Allows for extending the implementation to use other message queue implementations.
