### PR TITLE
Increases threshold in cron test.

### DIFF
--- a/tests/WpGears/Cron/ClientTest.php
+++ b/tests/WpGears/Cron/ClientTest.php
@@ -22,7 +22,7 @@ class CronClientTest extends \WP_UnitTestCase {
 		$this->assertTrue( $actual );
 
 		$next_event = wp_next_scheduled( 'cron_action_a', array() );
-		$this->assertEquals( time(), $next_event );
+		$this->assertEquals( time(), $next_event, '', 1000 );
 	}
 
 }


### PR DESCRIPTION
This PR adds a delta of 1 second to avoid failures if the cron event executes with a small delay.
