### PR TITLE
Traps fatal Gearman Exceptions on failure to register servers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,20 +9,20 @@
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.0.22",
+            "version": "v1.0.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046"
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/bd9b14f094c89c8b5804a4e41edeb7853bb85046",
-                "reference": "bd9b14f094c89c8b5804a4e41edeb7853bb85046",
+                "url": "https://api.github.com/repos/composer/installers/zipball/36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "1.0.0"
+                "composer-plugin-api": "^1.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
@@ -40,8 +40,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -56,12 +56,14 @@
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
                 "Craft",
                 "Dolibarr",
                 "Hurad",
+                "ImageCMS",
                 "MODX Evo",
+                "Mautic",
                 "OXID",
                 "SMF",
                 "Thelia",
@@ -103,7 +105,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2015-10-29 23:28:48"
+            "time": "2016-04-13 19:46:30"
         }
     ],
     "packages-dev": [
@@ -368,20 +370,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -405,7 +410,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -581,16 +586,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.2",
+            "version": "v2.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8"
+                "reference": "e4fbcc65f90909c999ac3b4dfa699ee6563a9940"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/34c8a4b51e751e7ea869b8262f883d008a2b81b8",
-                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e4fbcc65f90909c999ac3b4dfa699ee6563a9940",
+                "reference": "e4fbcc65f90909c999ac3b4dfa699ee6563a9940",
                 "shasum": ""
             },
             "require": {
@@ -626,7 +631,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-13 10:28:07"
+            "time": "2016-03-29 19:00:15"
         }
     ],
     "aliases": [],

--- a/includes/WpGears/Gearman/Client.php
+++ b/includes/WpGears/Gearman/Client.php
@@ -38,10 +38,21 @@ class Client extends BaseClient {
 		if ( $client !== false ) {
 			$servers = $this->get_servers();
 
-			if ( empty( $servers ) ) {
-				return $client->addServer();
-			} else {
-				return $client->addServers( implode( ',', $servers ) );
+			try {
+				if ( empty( $servers ) ) {
+					return $client->addServer();
+				} else {
+					return $client->addServers( implode( ',', $servers ) );
+				}
+			} catch ( \GearmanException $e ) {
+				$servers = implode( ',', $servers );
+
+				if ( ! defined( 'PHPUNIT_RUNNER' ) ) {
+					error_log( "Fatal Gearman Error: Failed to register servers ($servers)" );
+					error_log( "  Cause: " . $e->getMessage() );
+				}
+
+				return false;
 			}
 		} else {
 			return false;

--- a/tests/WpGears/Gearman/ClientTest.php
+++ b/tests/WpGears/Gearman/ClientTest.php
@@ -47,6 +47,16 @@ class GearmanClientTest extends \WP_UnitTestCase {
 	}
 
 	function test_it_will_not_register_if_no_valid_gearman_client() {
+		$this->client->gearman_client = \Mockery::mock()
+			->shouldReceive( 'addServer' )
+			->andThrow( new \GearmanException( 'Failed to set exception option' ) )
+			->getMock();
+
+		$actual = $this->client->register();
+		$this->assertFalse( $actual );
+	}
+
+	function test_it_will_trap_gearman_error_if_failed_to_register_servers() {
 		$this->client->gearman_client = false;
 		$actual = $this->client->register();
 		$this->assertFalse( $actual );

--- a/tests/WpGears/Gearman/WorkerTest.php
+++ b/tests/WpGears/Gearman/WorkerTest.php
@@ -52,6 +52,16 @@ class GearmanWorkerTest extends \WP_UnitTestCase {
 		$this->assertFalse( $actual );
 	}
 
+	function test_it_will_not_register_if_failed_to_add_servers() {
+		$this->worker->gearman_worker = \Mockery::mock()
+			->shouldReceive( 'addServer' )
+			->andThrow( new \GearmanException( 'Failed to set exception option' ) )
+			->getMock();
+
+		$actual = $this->worker->register();
+		$this->assertFalse( $actual );
+	}
+
 	function test_it_will_add_default_server_to_worker_if_not_defined() {
 		$mock = \Mockery::mock()
 			->shouldReceive( 'addServer' )

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,7 @@ define('PHPUNIT_RUNNER', true);
 
 if ( ! class_exists( '\GearmanException' ) ) {
 
-	class GearmanExtension extends \Exception {
+	class GearmanException extends \Exception {
 
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,3 +13,11 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 require $_tests_dir . '/includes/bootstrap.php';
 
 define('PHPUNIT_RUNNER', true);
+
+if ( ! class_exists( '\GearmanException' ) ) {
+
+	class GearmanExtension extends \Exception {
+
+	}
+
+}


### PR DESCRIPTION
Catches any exceptions thrown by Gearman during server registration. Without this the site gets a 500 error when the plugin is activated but Gearman is unavailable.
