### PR TITLE
Config instructions for ubuntu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Note: For some setups, the above will not work as ```/etc/default/gearman-job-se
 3. In the file paste the configuration all on one line:
 
 ```sh
--q MySQL --mysql-host=localhost --mysql-port=3306 --mysql-user=root --mysql-password=root --mysql-db=gearman --mysql-table=gearman_queue
+-q MySQL --mysql-host=localhost --mysql-port=3306 --mysql-user=<user> --mysql-password=<password> --mysql-db=gearman --mysql-table=gearman_queue
 ```
 
 Then restart the gearman-job-server: ```sudo service gearman-job-server restart```.

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ PARAMS="-q MySQL --mysql-host=localhost --mysql-port=3306 --mysql-user=<user> --
 
 Note: For some setups, the above will not work as ```/etc/default/gearman-job-server``` does not get read.  If you don't see the persistent queue setup then:
 
-1. Create a `gearman` db in mysql (the database must be present in the database, but when gearmand is initialized the first time it will create the table.
+1. Create a `gearman` db in mysql (the database must be present in the database, but when gearmand is initialized the first time it will create the table).
 2. Create a file in `/etc/gearmand.conf`
 3. In the file paste the configuration all on one line:
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,19 @@ Edit the gearman config at ```/etc/default/gearman-job-server```, adding the fol
 PARAMS="-q MySQL --mysql-host=localhost --mysql-port=3306 --mysql-user=<user> --mysql-password=<password> --mysql-db=gearman --mysql-table=gearman_queue"
 ```
 
+Note: For some setups, the above will not work as ```/etc/default/gearman-job-server``` does not get read.  If you don't see the persistent queue setup then:
+
+1. Create a `gearman` db in mysql (the database must be present in the database, but when gearmand is initialized the first time it will create the table.
+2. Create a file in `/etc/gearmand.conf`
+3. In the file paste the configuration all on one line:
+
+```sh
+-q MySQL --mysql-host=localhost --mysql-port=3306 --mysql-user=root --mysql-password=root --mysql-db=gearman --mysql-table=gearman_queue
+```
+
+Then restart the gearman-job-server: ```sudo service gearman-job-server restart```.
+
+
 ## Verification
 
 Once everything is installed, you can quickly make sure gearman is accepting jobs with the ```test-client.php``` and ```test-worker.php``` files. The worker is configured to reverse any text passed to it. In the client file, we pass "Hello World" to the worker.


### PR DESCRIPTION
On my local setup (VVV) I wasn't able to get the persistent mysql working for gearman.  Discovered that with some setups gearman won't read the configuration from `/etc/default/gearman-job-server`.  It turns out there is an alternate location which IS used so I updated the README.md to include this info for anyone who runs into the same issues I did.
