### PR TITLE
add action for after \GearmanWorker::work is called.

### DIFF
--- a/includes/WpGears/Gearman/Worker.php
+++ b/includes/WpGears/Gearman/Worker.php
@@ -77,7 +77,7 @@ class Worker extends BaseWorker {
 			$result = false;
 		}
 
-		do_action( 'wp_async_after_worker_works', $result, $this );
+		do_action( 'wp_async_task_after_work', $result, $this );
 
 		return $result;
 	}

--- a/includes/WpGears/Gearman/Worker.php
+++ b/includes/WpGears/Gearman/Worker.php
@@ -77,6 +77,8 @@ class Worker extends BaseWorker {
 			$result = false;
 		}
 
+		do_action( 'wp_async_after_worker_works', $result, $this );
+
 		return $result;
 	}
 


### PR DESCRIPTION
In a current implementation of WPGears we are running multiple jobs per worker but we need to kill any running workers when we do a deploy to the server and due to the environment we're in, the method I'd like to use is to check a version number in a file against a static property representing the version on worker instantiation.

I thought I could just do this version check at the end of the job callback and return the appropriate status code when calling `exit()` (i.e. non zero means fail, zero mean success).  However logging is showing that even if I exit with `exit(0)` Gearman returns the job to the queue and it is retried when the worker restarts.

The only way I've been able to successfully use this method to restart the worker without redoing a job unnecessarily is to call `exit(0)` after `\GearmanWorker::work()` has returned.

Hence this pull request adding an action to the end of `\WPGears\Gearman\Worker::work` which allows for client code to hook in to execute things at this point.
