### PR TITLE
WIP: RabbitMQ docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,13 +156,27 @@ Define the `WP_MINIONS_BACKEND` constant in your ```wp-config.php```.  Valid val
 define( 'WP_MINIONS_BACKEND', 'gearman' );
 ```
 
-If your gearman service not running locally or uses a non-standard port, you'll need define your gearman servers in ```wp-config.php```
-```php
+If your job queue service not running locally or uses a non-standard port, you'll need define your servers in ```wp-config.php```
+
+```:php
+# Gearman config
 global $gearman_servers;
 $gearman_servers = array(
   '127.0.0.1:4730',
 );
 ```
+
+```:php
+# RabbitMQ config
+global $rabbitmq_server;
+$rabbitmq_server = array(
+  'host'     => '127.0.0.1' ),
+  'port'     => 5672,
+  'username' => 'guest',
+  'password' => 'guest',
+);
+
+Note: On RabbitMQ the guest/guest account is the default administrator account, RabbitMQ will only allow connections connections on that account from localhost. Connections to any non-loopback address will be denied. See the RabbitMQ manual on [user management](https://www.rabbitmq.com/rabbitmqctl.8.html#User_Management) and [Access Control](https://www.rabbitmq.com/rabbitmqctl.8.html#Access_Control) for information on adding users and allowing them access to RabbitMQ resources.
 
 ## MySQL Persistent Queue (Recommended)
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ $gearman_servers = array(
 # RabbitMQ config
 global $rabbitmq_server;
 $rabbitmq_server = array(
-  'host'     => '127.0.0.1' ),
+  'host'     => '127.0.0.1',
   'port'     => 5672,
   'username' => 'guest',
   'password' => 'guest',


### PR DESCRIPTION
Added some basic configuration info for RabbitMQ to the readme. Do we want to add more instructions for installing RabbitMQ to the readme like we have for Gearman? I started adding it and it felt like too much info. We could link to other resources for installing the backend servers or start some new md files.