### PR TITLE
Allow either the 1.x or 2.x branch of composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "composer/installers": "~1.0",
+        "composer/installers": "~1.0 || ^2.0",
         "php-amqplib/php-amqplib": "2.8.0"
     },
 	"require-dev": {


### PR DESCRIPTION
### Description of the Change

This change adds the 2.x branch to the versions that will satisfy the composer installers dependency. [wpackagist](https://wpackagist.org) already does this. Currently this plugin is blocking my ability to upgrade the installers package.

### Alternate Designs

N/A

### Benefits

The ability to update application code.

### Possible Drawbacks

None.

### Verification Process

`composer update` still works.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

Regarding the last checkpoint: updating the tests to run on modern versions of PHP is something that would be worthwhile in the future, but is out of scope for this PR. This change does not make any changes that affect the PHP behavior of this plugin, so it should not be a concern regarding this PR specifically that I was unable to run the test suite.

### Applicable Issues

N/A

### Changelog Entry

N/A
